### PR TITLE
Update build system

### DIFF
--- a/bin/make
+++ b/bin/make
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "${WHALEDO_UID}" ]; then
-  WHALEDO_UID=$(id -u)
+  WHALEDO_UID=$UID
 fi
 
 docker run -v "$(pwd):/tmp/work" -w /tmp/work --env-file env.whaledo -u $WHALEDO_UID whaledo/os-development-x86 make "$@"

--- a/bin/make
+++ b/bin/make
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/bin/bash
 
-import sys
-import whaledo
+if [ -z "${WHALEDO_UID}" ]; then
+  WHALEDO_UID=$(id -u)
+fi
 
-exit_code = whaledo.run("os-development-x86", ["make"] + sys.argv[1:])
-exit(exit_code)
+docker run -v "$(pwd):/tmp/work" -w /tmp/work --env-file env.whaledo -u $WHALEDO_UID whaledo/os-development-x86 make "$@"

--- a/bin/nightly/build.sh
+++ b/bin/nightly/build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
+DIR=$(dirname $(readlink -f $0)) # Directory script is in.
+cd $DIR/../..
+
 # Hard-code UID to 1000 so Jenkins is happy.
-docker run -v "$(pwd):/tmp/work" -w /tmp/work --env-file env.whaledo -u 1000 whaledo/os-development-x86 make BUILD_TYPE=nightly NAME_SUFFIX="-$(date +'%Y-%m-%d')" iso
+export WHALEDO_UID=1000
+export BUILD_TYPE=nightly
+export NAME_SUFFIX="-$(date +'%Y-%m-%d')"
+
+./bin/make iso

--- a/bin/nightly/build.sh
+++ b/bin/nightly/build.sh
@@ -5,7 +5,5 @@ cd $DIR/../..
 
 # Hard-code UID to 1000 so Jenkins is happy.
 export WHALEDO_UID=1000
-export BUILD_TYPE=nightly
-export NAME_SUFFIX="-$(date +'%Y-%m-%d')"
 
-./bin/make iso
+./bin/make BUILD_TYPE=nightly NAME_SUFFIX="-$(date +'%Y-%m-%d')" iso


### PR DESCRIPTION
Remove the Python dependency in the build system &mdash; it now only requires Docker and Bash.

(There's a Python utility that remains, but it's only used for releasing nightlies and is run in a Docker container.)